### PR TITLE
fix: Add colon to "short ternary operator" example

### DIFF
--- a/dictionary/short-ternary.ini.rst
+++ b/dictionary/short-ternary.ini.rst
@@ -29,7 +29,7 @@ Is is a short version of the ternary operator, and it is often used to set defau
    
    <?php
    
-   $action = (empty($_POST['action'])) ? 'default';
+   $action = (empty($_POST['action'])) ?: 'default';
    
    ?>
 


### PR DESCRIPTION
I added the missing colon in "short ternary operator" example.